### PR TITLE
fixed LICENSE build issue, modified build commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,6 @@ jobs:
       - run: |
           export PATH=/opt/conda/bin:${PATH}
           make test
-  package:
-    docker:
-      - image: saturncloud/sutils-test
-    context: build
-    steps:
-      - checkout
-      - run: |
-          export PATH=/opt/conda/bin:${PATH}
-          export CONDA_OUTPUT=/tmp/output
-          make package
 workflows:
   version: 2
   build_test_image:
@@ -41,21 +31,4 @@ workflows:
     jobs:
       - test:
           context: build
-  package:
-    jobs:
-      - test:
-          context: build
-          filters:
-            tags:
-              only: /^prod.*/
-            branches:
-              ignore: /.*/
-      - package:
-          requires:
-            - test
-          context: build
-          filters:
-            tags:
-              only: /^prod.*/
-            branches:
-              ignore: /.*/
+  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - run: |
           export PATH=/opt/conda/bin:${PATH}
           make test
+          make build
 workflows:
   version: 2
   build_test_image:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ htmlcov
 .pytest_cache
 __pycache__/
 pdc.sqlite
+saturn-bld
+conda.recipe/LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
+include .env_deps
+
 push_test_image:
 	docker build -t saturncloud/sutils-test:latest dev-docker
 	docker push saturncloud/sutils-test:latest
 test:
 	py.test sutils
-dev_package:
-	bash ./dev_package.sh
-package:
-	bash ./package.sh
+test_in_docker:
+	docker run --rm -v $(shell pwd):/app --workdir /app \
+		saturncloud/sutils-test:latest \
+		/opt/conda/bin/conda run -n base make test
+build:
+	mkdir -p saturn-bld
+	conda build --output-folder=./saturn-bld --prefix-length 80 -c conda-forge -c saturncloud conda.recipe

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,2 +1,3 @@
 cd $RECIPE_DIR/../
 cp -rf sutils $SP_DIR/
+cp LICENSE $RECIPE_DIR

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: sutils
-  version: {{os.environ.get('CIRCLE_TAG').split('-')[-1]}}
+  version: {{os.environ.get('VERSION')}}
 build:
   number: 1
   noarch: generic

--- a/dev_package.sh
+++ b/dev_package.sh
@@ -1,6 +1,0 @@
-export CONDA_OUTPUT=/tmp/output
-rm -rf ${CONDA_OUTPUT}
-mkdir ${CONDA_OUTPUT}
-conda build --output-folder=$CONDA_OUTPUT --prefix-length 80 -c conda-forge -c saturncloud conda.recipe
-export TARGET=`ls ${CONDA_OUTPUT}noarch/sutils*.bz2`
-anaconda -t ${ANACONDA_TOKEN} upload -u saturncloud -l dev --force --no-progress

--- a/package.sh
+++ b/package.sh
@@ -1,6 +1,0 @@
-export CONDA_OUTPUT=/tmp/output
-rm -rf ${CONDA_OUTPUT}
-mkdir ${CONDA_OUTPUT}
-conda build --output-folder=$CONDA_OUTPUT --prefix-length 80 -c conda-forge -c saturncloud conda.recipe
-export TARGET=`ls ${CONDA_OUTPUT}/noarch/sutils*.bz2`
-anaconda -t ${ANACONDA_TOKEN} upload -u saturncloud -l dev -l main --force --no-progress


### PR DESCRIPTION
This PR fixes one build issue, adds helper commands for local testing, and removes packaging scripts (these have been moved to an internal build and release process).

* `LICENSE` - The file location was not visible to conda-build. Copying into `$RECIPE_DIR` and referencing from there seems to have fixed it. If there's a better way to do this, I'd love to do that instead.
* Packaging scripts and references to them have been removed. The conda recipe now uses `VERSION` instead of `CIRCLE_TAG` to determine the version to build.
* `build` and `test_in_docker` have been added for local dev convenience.